### PR TITLE
fix(ppp): rebase LED DTS patch for kernel 6.17.7

### DIFF
--- a/devices/pine64-pinephonepro/kernel/0001-dts-pinephone-pro-Setup-default-on-and-panic-LEDs.patch
+++ b/devices/pine64-pinephonepro/kernel/0001-dts-pinephone-pro-Setup-default-on-and-panic-LEDs.patch
@@ -13,24 +13,22 @@ yellow and green during the different boot stages.
  1 file changed, 2 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-pinephone-pro.dts b/arch/arm64/boot/dts/rockchip/rk3399-pinephone-pro.dts
-index 520d998bae9a..52ba7c82fad6 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-pinephone-pro.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-pinephone-pro.dts
-@@ -131,12 +131,14 @@ led-red {
+@@ -247,11 +247,13 @@
+ 		led_red: led-0 {
  			color = <LED_COLOR_ID_RED>;
- 			function = LED_FUNCTION_INDICATOR;
  			gpios = <&gpio4 RK_PD2 GPIO_ACTIVE_HIGH>;
 +			panic-indicator;
  		};
- 
- 		led-green {
+
+ 		led_green: led-1 {
  			color = <LED_COLOR_ID_GREEN>;
- 			function = LED_FUNCTION_INDICATOR;
  			gpios = <&gpio4 RK_PD5 GPIO_ACTIVE_HIGH>;
 +			linux,default-trigger = "default-on";
  		};
- 
- 		led-blue {
--- 
+
+ 		led_blue: led-2 {
+--
 2.34.0
 


### PR DESCRIPTION
## Summary
- Regenerated the PinePhone Pro LED DTS patch to match upstream kernel 6.17.7 DTS structure
- Updated context lines for renamed LED nodes (`led-0`/`led-1`/`led-2` with label prefixes) and removed stale `LED_FUNCTION_INDICATOR` references

Fixes #4