### PR TITLE
fix(plasma-mobile): remove unavailable maliit packages

### DIFF
--- a/modules/plasma-mobile.nix
+++ b/modules/plasma-mobile.nix
@@ -37,8 +37,6 @@ in
       plasma-dialer
       plasma-keyboard
       spacebar
-      maliit-framework
-      maliit-keyboard
     ] ++ lib.optionals cfg.installRecommendedSoftware (with pkgs.kdePackages; [
       alligator
       angelfish


### PR DESCRIPTION
## Summary
- Remove `maliit-framework` and `maliit-keyboard` from core packages in `modules/plasma-mobile.nix`
- These packages don't exist in `kdePackages` (only existed under `libsForQt5` for Plasma 5)

Fixes #9